### PR TITLE
Fix proof deletion

### DIFF
--- a/client-choo/components/confirmation-modal.js
+++ b/client-choo/components/confirmation-modal.js
@@ -13,8 +13,8 @@ module.exports = class ConfirmationModal extends Component {
     return true
   }
 
-  closeConfModal (err) {
-    this.emit('closeConfirmationModal', err)
+  closeConfModal () {
+    this.emit('closeConfirmationModal')
   }
 
   createElement (state) {
@@ -27,7 +27,7 @@ module.exports = class ConfirmationModal extends Component {
     const { config } = state.confirmationModal
 
     const proceedAndClose = () => {
-      config.proceedFunc(config.id, this.closeConfModal)
+      config.proceedFunc(config.id, () => { this.closeConfModal() })
     }
 
     return html`

--- a/client-choo/components/proof-detail.js
+++ b/client-choo/components/proof-detail.js
@@ -31,8 +31,10 @@ module.exports = class ProofDetail extends Component {
   deleteProof (proofHash, callback, IpfsID) {
     IpfsID.proofsDB.delete(proofHash).
       then((res) => {
-        this.emit('notify:success', 'Proof deleted')
         callback(null, res)
+        this.emit('notify:success', 'Proof deleted')
+        this.emit('updateProofsList')
+        this.closeModal()
       }).catch((ex) => {
         console.error(ex)
         this.emit('notify:error', 'Proof delete failed')

--- a/client-choo/components/proof.js
+++ b/client-choo/components/proof.js
@@ -1,6 +1,5 @@
 var html = require('choo/html')
 var Component = require('choo/component')
-const uuid = require('uuid/v1')
 const Clipboard = require('../node_modules/clipboard/dist/clipboard.min')
 
 const CONTENT_PROOFS = 'show-proofs'
@@ -46,22 +45,15 @@ module.exports = class Proof extends Component {
   }
 
   evtProofSave () {
-    const { IpfsID } = this.state
     // Save to local indexDB: save { 'proof:username:service': { ipfsUrl: <url>, ipnsUrl: <url>, timestamp: <ts> }
     let proof = JSON.parse(
       document.querySelector('#proof-preview-display').value.trim()
     )
     if (!proof) {
       this.emit('notify:error', 'Error', 'Cannot save non-existent proof')
+      return
     }
-    proof.id = uuid() //  TODO: do this inside library/API
-    IpfsID.proof.saveProof(proof).then((res) => {
-      this.emit('notify:success', 'Proof stored successfully')
-      this.emit('updateProofsList')
-    }).catch((ex) => {
-      console.error(ex)
-      this.emit('notify:error', 'Error: Cannot save proof')
-    })
+    this.emit('createProof', proof)
   }
 
   evtShowProofs () {

--- a/client-choo/stores/clicks.js
+++ b/client-choo/stores/clicks.js
@@ -2,6 +2,7 @@ const html = require('choo/html')
 const animate = require('../../client/animate')
 const { start, checkForAccount } = require('../../src/')
 const validUrl = require('valid-url')
+const uuid = require('uuid/v1')
 const { OBJECT, STRING, UNDEFINED,
         ARRAY, INTEGER, BOOL, FUNCTION } = require('../../src/utils')
 
@@ -176,6 +177,18 @@ function store (state, emitter) {
     emitter.on('updateProofContent', function (content) {
       state.currentProofContent = content
       emitter.emit(state.events.RENDER)
+    })
+
+    emitter.on('createProof', async function(proof) {
+      const { IpfsID } = state
+      proof.id = uuid() //  TODO: do this inside library/API
+      IpfsID.proof.saveProof(proof).then((res) => {
+        emitter.emit('notify:success', 'Proof stored successfully')
+        emitter.emit('updateProofsList')
+      }).catch((ex) => {
+        console.error(ex)
+        emitter.emit('notify:error', 'Error: Cannot save proof')
+      })
     })
 
     emitter.on('updateProofsList', async function() {
@@ -436,7 +449,7 @@ function store (state, emitter) {
       emitter.emit(state.events.RENDER)
     })
 
-    emitter.on('closeConfirmationModal', async function(config) {
+    emitter.on('closeConfirmationModal', async function() {
       state.confirmationModal = {}
       emitter.emit(state.events.RENDER)
     })


### PR DESCRIPTION
Minor fixes around proof deletion.
- get rid of conflicting notifications after deletion (both success and error messages)
- close modals upon deletion
- update proofs list after deletion
- bonus: move proof creation logic out of component, into the "store"