### PR TITLE
Gist auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -360,6 +360,14 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "asn1.js": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
@@ -396,6 +404,11 @@
         }
       }
     },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -427,11 +440,26 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "b64": {
       "version": "3.0.3",
@@ -535,6 +563,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        }
+      }
     },
     "bech32": {
       "version": "1.1.3",
@@ -1207,6 +1250,11 @@
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
       "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
     "catbox": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/catbox/-/catbox-7.1.5.tgz",
@@ -1448,6 +1496,11 @@
       "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
       "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
     },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1515,6 +1568,14 @@
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -1801,6 +1862,14 @@
         "es5-ext": "^0.10.9"
       }
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "data-queue": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/data-queue/-/data-queue-0.0.3.tgz",
@@ -2013,6 +2082,11 @@
         }
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -2222,6 +2296,22 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "dependencies": {
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        }
       }
     },
     "ecstatic": {
@@ -2924,8 +3014,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -3024,6 +3113,11 @@
         }
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -3038,8 +3132,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3292,6 +3385,21 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
       "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
     },
     "formdata": {
       "version": "0.10.4",
@@ -4581,6 +4689,24 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "gist-client": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/gist-client/-/gist-client-1.0.7.tgz",
+      "integrity": "sha1-LcJK+Pp9jiIf1R8JuvKvLaGrS48=",
+      "requires": {
+        "co": "^4.6.0",
+        "request": "^2.83.0",
+        "request-promise-native": "^1.0.5"
+      }
+    },
     "gists": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/gists/-/gists-2.0.0.tgz",
@@ -4826,6 +4952,43 @@
       "resolved": "https://registry.npmjs.org/hapi-set-header/-/hapi-set-header-1.0.2.tgz",
       "integrity": "sha1-KvrgAsZxnW1U8/qIRi+CKJLS3xM="
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+      "requires": {
+        "ajv": "^5.3.0",
+        "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+        }
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5054,6 +5217,16 @@
             "wordwrap": "~0.0.2"
           }
         }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -6405,6 +6578,11 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "items": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
@@ -6514,6 +6692,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6559,6 +6742,17 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "k-bucket": {
       "version": "4.0.1",
@@ -9101,6 +9295,11 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-assign": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
@@ -9805,6 +10004,11 @@
           "optional": true
         }
       }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pez": {
       "version": "2.1.5",
@@ -10902,6 +11106,51 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "^4.13.1"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -11635,6 +11884,34 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.0.tgz",
       "integrity": "sha1-z/yvcC2vZeo5u04PorKZzsGhvkY="
     },
+    "sshpk": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        }
+      }
+    },
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -11736,6 +12013,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-browserify": {
       "version": "2.0.1",
@@ -12577,6 +12859,16 @@
       "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
       "requires": {
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "vise": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@protobufjs/base64": "^1.1.2",
     "buffer": "^5.2.1",
-    "gists": "^2.0.0",
+    "gist-client": "^1.0.7",
     "ipfs": "^0.32.2",
     "ipfs-pubsub-room": "^1.4.0",
     "level-browserify": "^2.0.0",

--- a/src/example-auth.js
+++ b/src/example-auth.js
@@ -1,5 +1,5 @@
 // 1. replace githubToken with your own 'read-only' token with limited scopes and no write access
-// 2. rename this module to auth.js
+// 2. Copy this module to auth.js
 module.exports = {
   githubToken: '1234567891011121314151617181920'
 }

--- a/src/example-auth.js
+++ b/src/example-auth.js
@@ -1,0 +1,5 @@
+// 1. replace githubToekn with your own 'read-only' token with limited scopes and no write access
+// 2. rename this module to auth.js
+module.exports = {
+  githubToken: '1234567891011121314151617181920'
+}

--- a/src/example-auth.js
+++ b/src/example-auth.js
@@ -1,4 +1,4 @@
-// 1. replace githubToekn with your own 'read-only' token with limited scopes and no write access
+// 1. replace githubToken with your own 'read-only' token with limited scopes and no write access
 // 2. rename this module to auth.js
 module.exports = {
   githubToken: '1234567891011121314151617181920'

--- a/src/remote-proofs.js
+++ b/src/remote-proofs.js
@@ -16,6 +16,7 @@ class RemoteProofs {
 
   constructor (proof) {
     this.proofApi = proof
+    this.gistClient = gistClient
   }
 
   async getGist (id) {
@@ -190,7 +191,7 @@ class RemoteProofs {
                                 item.service,
                                 item,
                                 callback)
-      }, 500)
+      }, 1500)
     }
 
     async.mapSeries(gistArray, process, (err, results) => {

--- a/src/remote-proofs.js
+++ b/src/remote-proofs.js
@@ -176,7 +176,7 @@ class RemoteProofs {
     })
   }
 
-  async verifyMultipleGists (gistArray, callback) {
+  verifyMultipleGists (gistArray, callback) {
     const that = this
 
     if (!Array.isArray(gistArray) || !gistArray.length) {
@@ -185,13 +185,13 @@ class RemoteProofs {
 
     function process (item, callback) {
       setTimeout(() => {
-        // Github API Rate Limit may flag IP
+        // FIXED?? Github API Rate Limit may flag IP
         return that.processGist(item.url,
                                 item.username,
                                 item.service,
                                 item,
                                 callback)
-      }, 1500)
+      }, 250)
     }
 
     async.mapSeries(gistArray, process, (err, results) => {

--- a/src/remote-proofs.js
+++ b/src/remote-proofs.js
@@ -1,5 +1,12 @@
 const async = require('neo-async')
-const Gists = require('gists')
+try {
+  var ghToken = require('./auth').githubToken
+} catch (ex) {
+  throw new Error('Github read-only API token is required to get remote proofs')
+}
+const GistClient = require("gist-client")
+const gistClient = new GistClient()
+gistClient.setToken(ghToken)
 
 const { OBJECT, STRING, UNDEFINED,
         ARRAY, INTEGER, NUMBER, BOOL, FUNCTION } = require('./utils')
@@ -12,11 +19,13 @@ class RemoteProofs {
   }
 
   async getGist (id) {
-    if (!id) { throw new Error(ERR.ARG_REQ_ID) }
-
-    const gists = new Gists()
+    if (!id) {
+      throw new Error('Gist ID required')
+    }
     try {
-      return await gists.get(id)
+      let gist = await gistClient.getOneById(id)
+
+      return gist
     } catch (ex) {
       return {
         error: ex,
@@ -38,9 +47,9 @@ class RemoteProofs {
       throw new Error('gist is required')
     }
 
-    // JSON = gist -> body -> files -> first key -> content
-    let files = response.body.files
-    let keys = Object.keys(response.body.files)
+    // JSON = gist -> files -> first key -> content
+    let files = response.files
+    let keys = Object.keys(response.files)
 
     try {
       // TODO: for now assume there is only one document to deal with
@@ -166,7 +175,7 @@ class RemoteProofs {
     })
   }
 
-  verifyMultipleGists (gistArray, callback) {
+  async verifyMultipleGists (gistArray, callback) {
     const that = this
 
     if (!Array.isArray(gistArray) || !gistArray.length) {
@@ -181,11 +190,12 @@ class RemoteProofs {
                                 item.service,
                                 item,
                                 callback)
-      }, 2000)
+      }, 500)
     }
 
     async.mapSeries(gistArray, process, (err, results) => {
       if (err) {
+        console.error(err)
         return callback(err, results)
       }
       return callback(null, results)

--- a/test/remote-proofs.spec.js
+++ b/test/remote-proofs.spec.js
@@ -19,7 +19,7 @@ const mockProofAPI = {
 }
 
 describe("remote-proofs test suite", function () {
-  this.timeout(5000)
+  this.timeout(10000)
   const gistUrl =
         'https://gist.github.com/daviddahl/a818f62766893754a1d1f3c8b01c5cb6'
   const rp = new RemoteProofs(mockProofAPI)
@@ -53,10 +53,10 @@ describe("remote-proofs test suite", function () {
       rp.getGist(gistId).then((res) => {
 
         expect(typeof res).to.equal(OBJECT)
-        let keys = Object.keys(res.body.files)
+        let keys = Object.keys(res.files)
         expect(keys.length == 1)
         expect(keys[0]).to.equal('github-proof.json') // <-- arbitrary key name
-        let proof = res.body.files[keys[0]].content
+        let proof = res.files[keys[0]].content
 
         expect(typeof proof).to.equal(STRING)
 
@@ -120,14 +120,19 @@ describe("remote-proofs test suite", function () {
           service: 'github.com'
         }
       ]
-      rp.verifyMultipleGists(items, (err, valid) => {
-        expect(err).to.equal(null)
-        expect(valid[0].valid).to.equal(true)
-        expect(valid[1].valid).to.equal(true)
-        expect(valid[2].valid).to.equal(true)
-        expect(valid[0].doc.handle).to.equal('daviddahl')
-        done()
-      })
+      try {
+        rp.verifyMultipleGists(items, (err, valid) => {
+          console.log(err)
+          expect(err).to.equal(null)
+          expect(valid[0].valid).to.equal(true)
+          expect(valid[1].valid).to.equal(true)
+          expect(valid[2].valid).to.equal(true)
+          expect(valid[0].doc.handle).to.equal('daviddahl')
+          done()
+        })
+      } catch (ex) {
+        expect(ex).to.not.exist()
+      }
     })
 
     // TODO: test mix of invalid and valid gitst urls

--- a/test/remote-proofs.spec.js
+++ b/test/remote-proofs.spec.js
@@ -19,7 +19,7 @@ const mockProofAPI = {
 }
 
 describe("remote-proofs test suite", function () {
-  this.timeout(10000)
+  this.timeout(4000)
   const gistUrl =
         'https://gist.github.com/daviddahl/a818f62766893754a1d1f3c8b01c5cb6'
   const rp = new RemoteProofs(mockProofAPI)
@@ -120,19 +120,20 @@ describe("remote-proofs test suite", function () {
           service: 'github.com'
         }
       ]
-      try {
-        rp.verifyMultipleGists(items, (err, valid) => {
-          console.log(err)
-          expect(err).to.equal(null)
-          expect(valid[0].valid).to.equal(true)
-          expect(valid[1].valid).to.equal(true)
-          expect(valid[2].valid).to.equal(true)
-          expect(valid[0].doc.handle).to.equal('daviddahl')
-          done()
-        })
-      } catch (ex) {
-        expect(ex).to.not.exist()
-      }
+
+      rp.verifyMultipleGists(items, (err, valid) => {
+        console.log('err: ', err)
+        console.log(valid)
+
+        expect(err).to.equal(null)
+        expect(valid[0].valid).to.equal(true)
+        expect(valid[1].valid).to.equal(true)
+        expect(valid[2].valid).to.equal(true)
+        expect(valid[0].doc.handle).to.equal('daviddahl')
+        done()
+        // TODO: THIS TEST IS ACTUALLY WORKING BUT TIMES OUT. NOT SURE WHY
+      })
+
     })
 
     // TODO: test mix of invalid and valid gitst urls

--- a/test/remote-proofs.spec.js
+++ b/test/remote-proofs.spec.js
@@ -19,7 +19,7 @@ const mockProofAPI = {
 }
 
 describe("remote-proofs test suite", function () {
-  this.timeout(4000)
+  this.timeout(7000)
   const gistUrl =
         'https://gist.github.com/daviddahl/a818f62766893754a1d1f3c8b01c5cb6'
   const rp = new RemoteProofs(mockProofAPI)


### PR DESCRIPTION
Update gist client to require read-only token authentication for all gist fetching. This is much more stable and does not hit the github au-authed rate limiting

Developers looking to deploy Autonomica need to create a module at path: `src/auth.js`

See `src/example-auth.js`